### PR TITLE
Add use_backend when installing packages with DNF

### DIFF
--- a/rhelai-validation/tasks/setup.yaml
+++ b/rhelai-validation/tasks/setup.yaml
@@ -9,6 +9,7 @@
 
 - name: Install pciutils package
   ansible.builtin.dnf:
+    use_backend: dnf4
     name: pciutils
     state: present
 


### PR DESCRIPTION
This patch adds the "use_backend" to manually specify which module backend for installing packages with DNF.

This is required because ansible-core == 2.15 (which is used by the openstack-ansible-tests image fails if the "use_backend" is not specified.

Resolves: OSPRH-13975