### PR TITLE
Better ssh key handling and openstack.cloud

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .venv
 *.pyc
+tls-ca-bundle.pem
+creds.yaml

--- a/AnsibleTestCRD.yaml
+++ b/AnsibleTestCRD.yaml
@@ -11,11 +11,10 @@ spec:
     [control_node]
     localhost ansible_connection=local
     [target_nodes]
-    rhelai0 ansible_host=192.168.122.222 ansible_user=cloud-user ansible_ssh_private_key_file=~/rhel-ai.pem ansible_ssh_common_args='-o StrictHostKeyChecking=no'
+    rhelai0 ansible_host=192.168.122.222 ansible_user=cloud-user ansible_ssh_private_key_file=~/test_keypair.key ansible_ssh_common_args='-o StrictHostKeyChecking=no'
   # yamllint enable rule:line-length
   ansiblePlaybookPath: main.yaml
   ansibleVarFiles: |
-    deploy_rhelai_private_key_file: ~/rhel-ai.pem
     model_tests_enabled: false
     pci_devices:
       10de:20f1: 1

--- a/README.md
+++ b/README.md
@@ -20,8 +20,9 @@ Once the RHOSO + RHEL AI setup is complete, do the following:
 1. Set up and test your access to RHOSO
     ```
     oc cp openstackclient:.config/openstack/ ~/.config/openstack
+    oc cp openstackclient:/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem ./tls-ca-bundle.pem
     export OS_CLOUD=default
-    openstack --insecure flavor list
+    openstack --os-cacert ./tls-ca-bundle.pem flavor list
     ```
 1. Install Ansible dependencies
     ```

--- a/README.md
+++ b/README.md
@@ -17,9 +17,15 @@ Once the RHOSO + RHEL AI setup is complete, do the following:
     model_download_registry_username: "|3c5aa7e0-9bb9...."
     model_download_registry_password: "eyJhbGciOiJSUzUxMiJ9...."
     ```
-1. Ensure you are logged in to Openshift
+1. Set up and test your access to RHOSO
     ```
-    oc login ...
+    oc cp openstackclient:.config/openstack/ ~/.config/openstack
+    export OS_CLOUD=default
+    openstack --insecure flavor list
+    ```
+1. Install Ansible dependencies
+    ```
+    ansible-galaxy install -r requirements.yaml
     ```
 1. Run it (requires ansible-core>=2.15)
     ```
@@ -35,6 +41,10 @@ Once the RHOSO + RHEL AI setup is complete, do the following:
     test-operator-controller-manager   1/1     1            1           29d
     ```
 1. Adjust the `pci_devices` variable in AnsibleTestCRD.yaml to match your hardware
+1. Provide an SSH key to use for access to RHELAI VM
+    ```
+    oc create secret generic rhelai-vm-secret-key --from-file=ssh-privatekey=$HOME/.ssh/rhel-ai.pem
+    ```
 1. Launch the test container
     ```
     $ oc apply -f AnsibleTestCRD.yaml

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -1,0 +1,4 @@
+---
+collections:
+  - name: openstack.cloud
+    version: ">=2.4.1"

--- a/rhelai-validation/defaults/main.yaml
+++ b/rhelai-validation/defaults/main.yaml
@@ -4,19 +4,23 @@ deploy_rhelai_enabled: true
 # [string] Name of the VM to create and destroy
 deploy_rhelai_vm_name: rhel-ai
 # [string] Image to use when creating the VM
-deploy_rhelai_image_name: rhel-ai
+deploy_rhelai_image: rhel-ai
 # [string] Flavor to use when creating the VM
 deploy_rhelai_flavor: nvidia
+# [string] Keypair to use when creating the VM
+deploy_rhelai_key_name: rhel-ai
+# [string] Network to use when creating the VM
+deploy_rhelai_net_name: private
+# [string] Network to use when creating the VM
+deploy_rhelai_security_group: basic
 # [string] Floating IP to assign to the VM
 deploy_rhelai_floating_ip: 192.168.122.222
 # [string] WARNING Where to (over-)write the ssh key. Must match path in inventory
-deploy_rhelai_private_key_file: ~/.ssh/rhel-ai.pem
+deploy_rhelai_private_key_file: ~/test_keypair.key
 # [bool] Whether to clean up the VM before running tests
 deploy_rhelai_pre_cleanup_enabled: true
 # [bool] Whether to clean up the VM after running tests
 deploy_rhelai_post_cleanup_enabled: false
-# [string] Set to "openstack" if it's available locally
-deploy_rhelai_openstack_command: openstack
 
 # [string] DNS server to inject into /etc/resolv.conf
 dns_server: 192.168.122.1

--- a/rhelai-validation/defaults/main.yaml
+++ b/rhelai-validation/defaults/main.yaml
@@ -21,6 +21,8 @@ deploy_rhelai_private_key_file: ~/test_keypair.key
 deploy_rhelai_pre_cleanup_enabled: true
 # [bool] Whether to clean up the VM after running tests
 deploy_rhelai_post_cleanup_enabled: false
+# [string] Where to find RHOSO certificates for openstack.cloud modules
+deploy_rhelai_ca_cert_path: /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
 
 # [string] DNS server to inject into /etc/resolv.conf
 dns_server: 192.168.122.1

--- a/rhelai-validation/tasks/vm_cleanup.yaml
+++ b/rhelai-validation/tasks/vm_cleanup.yaml
@@ -3,4 +3,4 @@
   openstack.cloud.server:
     name: "{{ deploy_rhelai_vm_name }}"
     state: absent
-    validate_certs: false
+    ca_cert: "{{ deploy_rhelai_ca_cert_path }}"

--- a/rhelai-validation/tasks/vm_cleanup.yaml
+++ b/rhelai-validation/tasks/vm_cleanup.yaml
@@ -1,14 +1,6 @@
 ---
 - name: Delete VM {{ deploy_rhelai_vm_name }}
-  ansible.builtin.command: "{{ deploy_rhelai_openstack_command }} --insecure server delete {{ deploy_rhelai_vm_name }}"
-  environment:
-    OS_CLOUD: default
-  changed_when: true
-  failed_when: false
-
-- name: Delete openstack keypair for {{ deploy_rhelai_vm_name }}
-  ansible.builtin.command: "{{ deploy_rhelai_openstack_command }} --insecure keypair delete {{ deploy_rhelai_vm_name }}"
-  environment:
-    OS_CLOUD: default
-  changed_when: true
-  failed_when: false
+  openstack.cloud.server:
+    name: "{{ deploy_rhelai_vm_name }}"
+    state: absent
+    validate_certs: false

--- a/rhelai-validation/tasks/vm_deploy.yaml
+++ b/rhelai-validation/tasks/vm_deploy.yaml
@@ -1,33 +1,18 @@
 ---
-- name: Create openstack keypair for {{ deploy_rhelai_vm_name }}
-  ansible.builtin.command: "{{ deploy_rhelai_openstack_command }} --insecure keypair create {{ deploy_rhelai_vm_name }}"
-  environment:
-    OS_CLOUD: default
-  no_log: true
-  register: output
-  changed_when: true
-
-- name: Write ssh key to file for {{ deploy_rhelai_vm_name }}
-  ansible.builtin.copy:
-    content: "{{ output.stdout }}\n"
-    dest: "{{ deploy_rhelai_private_key_file }}"
-    mode: "0600"
-
 - name: Create VM {{ deploy_rhelai_vm_name }}
-  ansible.builtin.command: |
-    {{ deploy_rhelai_openstack_command }} --insecure server create --flavor {{ deploy_rhelai_flavor }} \
-    --image {{ deploy_rhelai_image_name }} --key-name {{ deploy_rhelai_vm_name }} \
-    --nic net-id=private {{ deploy_rhelai_vm_name }} --security-group basic --wait
-  environment:
-    OS_CLOUD: default
-  changed_when: true
-
-- name: Add floating IP to {{ deploy_rhelai_vm_name }}
-  ansible.builtin.command: |
-    {{ deploy_rhelai_openstack_command }} --insecure server add floating ip {{ deploy_rhelai_image_name }} {{ deploy_rhelai_floating_ip }}
-  environment:
-    OS_CLOUD: default
-  changed_when: true
+  openstack.cloud.server:
+    state: present
+    name: "{{ deploy_rhelai_vm_name }}"
+    flavor: "{{ deploy_rhelai_flavor }}"
+    image: "{{ deploy_rhelai_image }}"
+    key_name: "{{ deploy_rhelai_key_name }}"
+    nics:
+      - net-name: "{{ deploy_rhelai_net_name }}"
+    floating_ips:
+      - "{{ deploy_rhelai_floating_ip }}"
+    security_groups:
+      - "{{ deploy_rhelai_security_group }}"
+    validate_certs: false
 
 - name: Poll for SSH to be available on {{ deploy_rhelai_vm_name }}
   ansible.builtin.command: |

--- a/rhelai-validation/tasks/vm_deploy.yaml
+++ b/rhelai-validation/tasks/vm_deploy.yaml
@@ -12,7 +12,7 @@
       - "{{ deploy_rhelai_floating_ip }}"
     security_groups:
       - "{{ deploy_rhelai_security_group }}"
-    validate_certs: false
+    ca_cert: "{{ deploy_rhelai_ca_cert_path }}"
 
 - name: Poll for SSH to be available on {{ deploy_rhelai_vm_name }}
   ansible.builtin.command: |

--- a/rhelai-validation/tasks/vm_pre.yaml
+++ b/rhelai-validation/tasks/vm_pre.yaml
@@ -2,15 +2,12 @@
 - name: RHEL AI VM setup
   when: deploy_rhelai_enabled | bool
   block:
-    - name: Install python-openstackclient
-      ansible.builtin.pip:
-        name: python-openstackclient
-      become: true
-      when: deploy_rhelai_openstack_command == "openstack"
-
     - name: VM Cleanup (Pre)
       ansible.builtin.import_tasks: vm_cleanup.yaml
       when: deploy_rhelai_pre_cleanup_enabled | bool
+
+    - name: Set up SSH key for VM
+      ansible.builtin.import_tasks: vm_sshkey.yaml
 
     - name: VM Deploy
       ansible.builtin.import_tasks: vm_deploy.yaml

--- a/rhelai-validation/tasks/vm_sshkey.yaml
+++ b/rhelai-validation/tasks/vm_sshkey.yaml
@@ -18,13 +18,13 @@
       openstack.cloud.keypair:
         name: "{{ deploy_rhelai_key_name }}"
         state: absent
-        validate_certs: false
+        ca_cert: "{{ deploy_rhelai_ca_cert_path }}"
     - name: Create openstack keypair from supplied key
       openstack.cloud.keypair:
         name: "{{ deploy_rhelai_key_name }}"
         public_key: "{{ keygen_result.stdout }}"
         state: replace
-        validate_certs: false
+        ca_cert: "{{ deploy_rhelai_ca_cert_path }}"
 
 - name: Create new SSH key
   when: not privkey_stat_result.stat.exists
@@ -34,12 +34,12 @@
       openstack.cloud.keypair:
         name: "{{ deploy_rhelai_key_name }}"
         state: absent
-        validate_certs: false
+        ca_cert: "{{ deploy_rhelai_ca_cert_path }}"
     - name: Create new openstack keypair
       openstack.cloud.keypair:
         name: "{{ deploy_rhelai_key_name }}"
         state: replace
-        validate_certs: false
+        ca_cert: "{{ deploy_rhelai_ca_cert_path }}"
       register: keypair_result
 
     - name: Write new ssh private key to file

--- a/rhelai-validation/tasks/vm_sshkey.yaml
+++ b/rhelai-validation/tasks/vm_sshkey.yaml
@@ -1,0 +1,50 @@
+---
+- name: Check if SSH privkey exists
+  ansible.builtin.stat:
+    path: "{{ deploy_rhelai_private_key_file }}"
+  register: privkey_stat_result
+
+- name: Use provided SSH key
+  when: privkey_stat_result.stat.exists
+  block:
+    - name: Generate SSH pubkey from provided key
+      ansible.builtin.command: ssh-keygen -y -f {{ deploy_rhelai_private_key_file | quote }}
+      register: keygen_result
+      changed_when: false
+      failed_when: keygen_result.rc != 0
+
+    # Only doing this because `state: replace` isn't working for me
+    - name: Delete existing openstack keypair
+      openstack.cloud.keypair:
+        name: "{{ deploy_rhelai_key_name }}"
+        state: absent
+        validate_certs: false
+    - name: Create openstack keypair from supplied key
+      openstack.cloud.keypair:
+        name: "{{ deploy_rhelai_key_name }}"
+        public_key: "{{ keygen_result.stdout }}"
+        state: replace
+        validate_certs: false
+
+- name: Create new SSH key
+  when: not privkey_stat_result.stat.exists
+  block:
+    # Only doing this because `state: replace` isn't working for me
+    - name: Delete existing openstack keypair
+      openstack.cloud.keypair:
+        name: "{{ deploy_rhelai_key_name }}"
+        state: absent
+        validate_certs: false
+    - name: Create new openstack keypair
+      openstack.cloud.keypair:
+        name: "{{ deploy_rhelai_key_name }}"
+        state: replace
+        validate_certs: false
+      register: keypair_result
+
+    - name: Write new ssh private key to file
+      ansible.builtin.copy:
+        content: "{{ keypair_result.keypair.private_key }}\n"
+        dest: "{{ deploy_rhelai_private_key_file }}"
+        mode: "0600"
+      no_log: true

--- a/vars.yaml
+++ b/vars.yaml
@@ -1,2 +1,3 @@
 ---
 deploy_rhelai_private_key_file: ~/.ssh/rhel-ai.pem
+deploy_rhelai_ca_cert_path: ./tls-ca-bundle.pem

--- a/vars.yaml
+++ b/vars.yaml
@@ -1,3 +1,2 @@
 ---
-# For when you have `oc` access to RHOSO, but no working `openstack` client installed
-deploy_rhelai_openstack_command: oc rsh openstackclient openstack
+deploy_rhelai_private_key_file: ~/.ssh/rhel-ai.pem


### PR DESCRIPTION
* Support for using the ~/test_keypair.key in the test-operator container (mounted from an openshift secret) 
* Moved notes about key creation from CRD to README
* Moved from openstackcli to openstack.cloud ansible collection
* Added requirements.yaml for openstack.cloud